### PR TITLE
Fix: Submenu is no longer stuck inside region

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -60,7 +60,7 @@
                     <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         Tidal Regions
                     </button>
-                    <ul class="dropdown-menu scrollable-menu tidal region" role="menu">
+                    <ul class="dropdown-menu tidal region" role="menu">
                         {% for us_region_element in us_regions %}
                             <li class="dropdown-submenu"><a tabindex="-1" href="#" class="dropdown-item station" data-name="{{ us_region_element }}">{{ us_region_element }}<span class="caret"></span></a>
                                 <ul class="dropdown-menu scrollable-menu">

--- a/tide_scraper.py
+++ b/tide_scraper.py
@@ -17,6 +17,7 @@ def get_stations_dict():
     stations_dict = dict()
     regions = soup.findAll("div", attrs={'class': 'span12 areaheader'})
     keys = []
+    temp = [] 
 
     for region in regions:
         keys.append(region.get('id'))
@@ -25,7 +26,6 @@ def get_stations_dict():
     for key in stations_dict:
         for region in regions:
             if key in region.get('id'):
-                temp = []
                 sub_regions = region.findAll("div", attrs={'class': lambda l: l and l.startswith('span4')})
                 for sub_region in sub_regions:
                     value = "%s" % sub_region.find('a').text


### PR DESCRIPTION
I've fixed the issue of the dropdowns opening in the same box.  The problem is that the outermost `ul` was part of the `scrollable-menu` class.  This causes everything within the `ul` tag to be seen as part of a single scrollable menu including the the inner `ul` tag.

To fix this I simply got rid of the scrollable-menu class:
`<ul class="dropdown-menu  tidal region" role="menu">`

<img width="1440" alt="Screen Shot 2019-03-19 at 4 58 36 PM" src="https://user-images.githubusercontent.com/22701154/54656098-6e5aa800-4a68-11e9-9827-691368b6e3ce.png">

I also ran into an issue saying "local variable 'temp' referenced before assignment".  This was fixed in `tide_scraper.py` by moving the `temp = []` assignment out of the loop.